### PR TITLE
Fix password reset flow issues with deep linking

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -59,6 +59,14 @@ module.exports = {
     infoPlist: {
       NSLocationWhenInUseUsageDescription: "Allow Card Show Finder to access your location so we can display nearby card shows."
     },
+    /* ------------------------------------------------------------------
+     * Universal Links (iOS) – ensure password-reset email links open
+     * the app rather than Safari.  Replace the domain below with the
+     * production domain used for your Supabase redirect / link-shortener.
+     * ------------------------------------------------------------------ */
+    associatedDomains: [
+      "applinks:cardshowfinder.app"
+    ],
     bundleIdentifier: "com.kaczcards.cardshowfinder"
   },
   android: {
@@ -74,6 +82,35 @@ module.exports = {
     ],
     jsEngine: "jsc",
     package: "com.kaczcards.cardshowfinder"
+    ,
+    /* ------------------------------------------------------------------
+     * Deep-link / Intent filters (Android)
+     *  – Handles both the custom scheme  cardshowfinder://reset-password
+     *    and the universal https link  https://cardshowfinder.app/reset-password
+     * ------------------------------------------------------------------ */
+    intentFilters: [
+      {
+        action: "VIEW",
+        data: [
+          {
+            scheme: "https",
+            host: "cardshowfinder.app",
+            pathPrefix: "/reset-password"
+          }
+        ],
+        category: ["BROWSABLE", "DEFAULT"]
+      },
+      {
+        action: "VIEW",
+        data: [
+          {
+            scheme: "cardshowfinder",
+            host: "reset-password"
+          }
+        ],
+        category: ["BROWSABLE", "DEFAULT"]
+      }
+    ]
   },
   web: {
     favicon: "./assets/favicon.png"

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -50,7 +50,11 @@ const RootNavigator: React.FC = () => {
    *  as long as we declare the screen name in the config.
    */
   const linking = {
-    prefixes: ['cardshowfinder://'],
+    // Accept both the custom-scheme URL and the universal https link
+    prefixes: [
+      'cardshowfinder://',
+      'https://cardshowfinder.app',
+    ],
     config: {
       screens: {
         // Auth flow


### PR DESCRIPTION
# Fix Password Reset Flow (iOS & Android)

## 🚀 Overview
This PR finishes the **password-reset experience** so users can successfully change their password from the e-mail link on both iOS and Android.

Previously the reset e-mail was sent, but clicking the link opened a blank page because the app did not recognise the deep-link.  
The flow is now end-to-end:

1. User taps **Change Password** in Profile → reset e-mail is sent.  
2. User clicks the link in the e-mail.  
3. The app launches, detects the `token` in the URL and shows **ResetPasswordScreen**.  
4. User enters a new password → Supabase updates the account.  
5. User is routed back to **Login** and can sign-in with the new credentials.

## ✨ Key Changes
| Area | Change |
|------|--------|
| **Auth Service** | • `resetPassword` now sends platform-appropriate `redirectTo` (custom scheme on iOS, universal link on Android).<br>• Added `updatePassword(newPassword, accessToken)` helper. |
| **Deep Linking** | • Added universal-link & custom-scheme prefixes in `RootNavigator`.<br>• Updated **app.config.js** with `associatedDomains` (iOS) & `intentFilters` (Android). |
| **UI / Screens** | • **ResetPasswordScreen** created: token parsing, validation, error states, optional debug log.<br>• **AuthNavigator** registered the new screen. |
| **ProfileScreen** | • “Change Password” button shows loader and calls `resetPassword`. |
| **Developer Tooling** | Debug panel (DEV only) in ResetPasswordScreen to aid QA. |

## 🧪 Testing
1. Build & install the app (`expo run:ios` / `run:android`) **with device e-mail client logged in**.  
2. Navigate to **Profile → Change Password**.  
3. Confirm toast / alert that e-mail was sent.  
4. Open the mail, click the link:  
   * iOS → `cardshowfinder://reset-password?token=…`  
   * Android → `https://cardshowfinder.app/reset-password?token=…`  
5. App opens on **Reset Password** screen; enter & confirm a new password (≥ 8 chars).  
6. Tap **Update Password** – alert shows success and you are returned to **Login**.  
7. Sign-in with the new password ✔️

## 🔍 Edge-Cases Handled
* Missing / expired token shows friendly message & “Request New Reset Link”.
* Links opened while the app is **already running** are handled via `Linking.addEventListener`.
* Invalid URLs are logged (DEV) without crashing the app.

## 📸 Screenshots
*(see attached images in PR)*

---

Ready for review 🙏
