### PR TITLE
feat: Enable show organizers to register as dealers

### DIFF
--- a/src/screens/Dealer/ShowParticipationScreen.tsx
+++ b/src/screens/Dealer/ShowParticipationScreen.tsx
@@ -413,7 +413,17 @@ const ShowParticipationScreen: React.FC = () => {
   };
   
   // Check if user is a dealer
-  const isDealer = user && (user.role === UserRole.DEALER || user.role === UserRole.MVP_DEALER);
+  /**
+   * Users allowed to access this screen:
+   *   • Regular dealers
+   *   • MVP dealers
+   *   • Show organizers (who may also sell as dealers)
+   */
+  const isDealer =
+    user &&
+    (user.role === UserRole.DEALER ||
+      user.role === UserRole.MVP_DEALER ||
+      user.role === UserRole.SHOW_ORGANIZER);
   
   if (!isDealer) {
     return (


### PR DESCRIPTION
- Update ShowParticipationScreen role check to include SHOW_ORGANIZER
- Allow organizers to register as dealers for their own shows or others
- Keep MVP upgrade messaging restricted to regular dealers only
- Add detailed comments explaining user access permissions
- Maintain existing functionality for all dealer types

This enables the business use case where show organizers can:
1. Sell as dealers at shows they organize
2. Register as dealers at shows organized by others
3. Access full dealer booth management features