### PR TITLE
fix: Allow show organizers to register as dealers in backend

### DIFF
--- a/src/services/dealerService.ts
+++ b/src/services/dealerService.ts
@@ -217,7 +217,7 @@ export const registerForShow = async (
      */
     const rawRole = (userData?.role || '').toString().toLowerCase();
     const isDealerLike =
-      rawRole.includes('dealer') || rawRole.includes('mvp');
+      rawRole.includes('dealer') || rawRole.includes('mvp') || rawRole.includes('organizer'); // allow organizers
 
     if (
       !userRole &&
@@ -233,7 +233,8 @@ export const registerForShow = async (
 
     if (
       effectiveRole !== UserRole.DEALER &&
-      effectiveRole !== UserRole.MVP_DEALER
+      effectiveRole !== UserRole.MVP_DEALER &&
+      effectiveRole !== UserRole.SHOW_ORGANIZER // organizers can register as dealers
     ) {
       return { data: null, error: 'User is not a dealer' };
     }


### PR DESCRIPTION
- Update registerForShow role validation to include SHOW_ORGANIZER
- Modify lenient role check to accept 'organizer' in role string
- Update strict role check to allow UserRole.SHOW_ORGANIZER
- Resolves 'User is not a dealer' error when organizers try to register

This completes the organizer-as-dealer functionality by fixing the backend validation that was blocking show organizers from saving their dealer registrations despite having frontend access.