### PR TITLE
fix: resolve EAS build deployment issues

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -36,7 +36,8 @@
       },
       "cache": {
         "key": "staging-${{ github.sha }}",
-        "cacheDefaultPaths": true
+        /* default cache paths are applied automatically;
+           deprecated flag removed per Expo docs */
       },
       "ios": {
         "resourceClass": "m-medium",
@@ -46,6 +47,7 @@
       "android": {
         "resourceClass": "large",
         "autoIncrement": "versionCode",
+        "credentialsSource": "remote",
         "buildType": "app-bundle"
       }
     },
@@ -66,6 +68,7 @@
       "android": {
         "resourceClass": "large",
         "autoIncrement": "versionCode",
+        "credentialsSource": "remote",
         "buildType": "app-bundle"
       }
     }


### PR DESCRIPTION
1. Remove deprecated 'cacheDefaultPaths' field from staging build profile
   - Expo now applies default cache paths automatically
   - Deprecated field was causing warnings in CI

2. Add 'credentialsSource: remote' to Android build configurations
   - Prevents 'Generating a new Keystore is not supported in --non-interactive mode' error
   - Ensures builds use remote credentials stored on EAS servers
   - Applied to both staging and production Android configurations

This resolves the deployment pipeline failures in the continuous deployment phase.