### PR TITLE
fix: add preview build profile and ensure all Android builds use remo…

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -23,8 +23,30 @@
         "gradleCommand": ":app:assembleDebug",
         "resourceClass": "medium",
         "autoIncrement": "versionCode",
-        "credentialsSource": "local",
+        "credentialsSource": "remote",
         "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "developmentClient": false,
+      "channel": "preview",
+      "env": {
+        "APP_ENV": "preview"
+      },
+      "cache": {
+        "key": "preview-${{ github.sha }}"
+      },
+      "ios": {
+        "resourceClass": "m-medium",
+        "autoIncrement": "buildNumber",
+        "scheme": "cardshowfinderPreview"
+      },
+      "android": {
+        "resourceClass": "large",
+        "autoIncrement": "versionCode",
+        "credentialsSource": "remote",
+        "buildType": "app-bundle"
       }
     },
     "staging": {


### PR DESCRIPTION
…te credentials

The deployment was failing because:
1. EAS was defaulting to 'preview' environment but no preview profile existed
2. Development profile was still using local credentials

Changes:
- Add 'preview' build profile with remote credentials for Android
- Update development profile to use 'credentialsSource: remote'
- Ensure all Android configurations use remote credentials consistently

This prevents 'Generating a new Keystore is not supported in --non-interactive mode' errors across all build profiles used by CI/CD pipelines.