### PR TITLE
fix: resolve iOS version format and credential issues for deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,10 +83,11 @@ jobs:
           elif [[ "${{ github.ref }}" == "refs/tags/v"* ]]; then
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           else
-            # Generate version based on date and commit hash
-            TIMESTAMP=$(date +'%Y%m%d.%H%M')
-            SHORT_SHA=$(git rev-parse --short HEAD)
-            echo "version=${TIMESTAMP}-${SHORT_SHA}" >> $GITHUB_OUTPUT
+            # Auto-generate Apple-compatible version string (major.minor.build)
+            # We keep major/minor static (1.0) and derive an ever-increasing
+            # numeric BUILD_NUMBER from the current UTC timestamp (YYYYMMDDHHMM).
+            BUILD_NUMBER=$(date -u +'%Y%m%d%H%M')
+            echo "version=1.0.${BUILD_NUMBER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate build ID
@@ -217,12 +218,17 @@ jobs:
           set -e
           
           # Build iOS with the determined environment profile
-          echo "🍎 Building iOS app with profile: ${{ needs.determine-environment.outputs.environment }}"
-          eas build \
-            --platform ios \
-            --profile ${{ needs.determine-environment.outputs.environment }} \
-            --non-interactive \
-            --no-wait
+          if [[ "${{ needs.determine-environment.outputs.environment }}" == "production" ]]; then
+            echo "🍎 Building iOS app with profile: production"
+            eas build \
+              --platform ios \
+              --profile production \
+              --non-interactive \
+              --no-wait
+          else
+            echo "ℹ️  Skipping iOS build for internal distribution environment (${{
+              needs.determine-environment.outputs.environment }})."
+          fi
           
           # Build Android with development profile (which has credentials) or fallback to specified environment
           ANDROID_PROFILE="${USE_DEV_PROFILE_FOR_ANDROID:-${{ needs.determine-environment.outputs.environment }}}"


### PR DESCRIPTION
Critical fixes for deployment pipeline:

1. **Apple-compatible version format**:
   - Changed from timestamp format (20250806.1804-a6081a33) to Apple format (1.0.BUILD_NUMBER)
   - Uses format like '1.0.202508061804' which Apple accepts
   - Maintains unique, incrementing build numbers based on UTC timestamp

2. **iOS credential handling**:
   - Skip iOS builds for internal distribution environments (staging, preview)
   - Only build iOS for production profile where credentials are properly configured
   - Prevents 'EAS CLI couldn't find credentials suitable for internal distribution' error

3. **Platform-specific build strategy**:
   - iOS: Production builds only (where App Store credentials exist)
   - Android: All environments (uses remote keystore credentials)

This addresses the two main deployment blockers:
- Version format rejection by Apple's validation
- Missing iOS credentials for internal distribution