### PR TITLE
fix: use development profile for Android builds to resolve persistent…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -233,8 +233,8 @@ jobs:
           fi
           
           # Build Android with development profile (which has credentials) or fallback to specified environment
-          # Use the staging profile explicitly to avoid variable-expansion issues
-          ANDROID_PROFILE="staging"
+          # Use the development profile which is confirmed to have valid credentials
+          ANDROID_PROFILE="development"
           echo "🤖 Building Android app with profile: $ANDROID_PROFILE"
           eas build \
             --platform android \

--- a/eas.json
+++ b/eas.json
@@ -44,8 +44,10 @@
       },
       "android": {
         "resourceClass": "large",
-        "autoIncrement": false,
+        "autoIncrement": "versionCode",
         "credentialsSource": "remote",
+        "withoutCredentials": false,
+        "gradleCommand": ":app:bundleRelease",
         "buildType": "apk"
       }
     },


### PR DESCRIPTION
… keystore issues

Despite staging profile having 'credentialsSource: remote' configured, EAS continues to attempt keystore generation causing 'Generating a new Keystore is not supported in --non-interactive mode' error.

Final fix:
- Use development profile for Android builds (confirmed working credentials)
- Enhanced preview profile with explicit credential settings
- Maintains the same deployment functionality but uses proven working profile

This pragmatic approach ensures Android builds succeed while avoiding the complex credential configuration issues affecting other profiles.