### PR TITLE
fix(userRole): normalizeRole should map to lowercase enum values\n\n-…

### DIFF
--- a/src/services/userRoleService.ts
+++ b/src/services/userRoleService.ts
@@ -32,8 +32,8 @@ export const IS_TEST_MODE = false;
  */
 export const normalizeRole = (role?: string | null): UserRole | null => {
   if (!role) return null;
-  const upper = role.toUpperCase() as UserRole;
-  return (Object.values(UserRole) as string[]).includes(upper) ? upper : null;
+  const lower = role.toLowerCase() as UserRole;
+  return (Object.values(UserRole) as string[]).includes(lower) ? lower : null;
 };
 
 /* ------------------------------------------------------------------


### PR DESCRIPTION
… UserRole enum values are lowercase strings; map DB role strings to lowercase\n- Prevents normalizeRole from always returning null\n\nDroid-assisted change