### PR TITLE
chore(query): guard PostgREST .in filters when arrays may be empty\n\…

### DIFF
--- a/src/screens/ShowDetail/hooks/useShowDetail.ts
+++ b/src/screens/ShowDetail/hooks/useShowDetail.ts
@@ -179,6 +179,13 @@ export const useShowDetail = (
       }
 
       const participantUserIds = [...new Set(participants.map((p) => p.userid))];
+
+      // Early-exit guard: nothing to look up → clear list & stop
+      if (participantUserIds.length === 0) {
+        setParticipatingDealers([]);
+        return;
+      }
+
       const { data: dealerProfiles, error: profilesError } = await supabase
         .from('profiles')
         .select('id, first_name, last_name, profile_image_url, role, account_type')

--- a/src/services/dealerService.ts
+++ b/src/services/dealerService.ts
@@ -429,6 +429,11 @@ export const getDealersForShow = async (
     // Step 2: Extract user IDs from participants
     const userIds = participantsData.map(participant => participant.userid);
 
+    // Early-exit guard: no user IDs to look up → nothing to return
+    if (!userIds || userIds.length === 0) {
+      return { data: [], error: null };
+    }
+
     // Step 3: Fetch profiles for these user IDs
     // Only select columns that definitely exist in the schema
     const { data: profilesData, error: profilesError } = await supabase

--- a/src/services/showService.ts
+++ b/src/services/showService.ts
@@ -1064,6 +1064,11 @@ export const getUpcomingShows = async (params: {
       .map((row: any) => row.showid)
       .filter(Boolean);
 
+    // Early-exit guard: nothing to look up → return empty list
+    if (showIds.length === 0) {
+      return { data: [], error: null };
+    }
+
     /* -----------------------------------------------------------
      * 2. Fetch shows matching those IDs + date filters
      * --------------------------------------------------------- */


### PR DESCRIPTION
…n- showService.getUpcomingShows: early return if showIds length is 0\n- useShowDetail.fetchParticipatingDealers: early return if participantUserIds is empty\n- dealerService.getDealersForShow: early return if userIds is empty\n\nPrevents accidental  with an empty list\n\nDroid-assisted change