### PR TITLE
refactor(role): unify UserRole enum via types and use normalizeRole f…

### DIFF
--- a/src/services/dealerService.ts
+++ b/src/services/dealerService.ts
@@ -7,6 +7,7 @@
 import { supabase } from '../supabase';
 import { Show, UserRole } from '../types';
 import { formatInList } from '../utils/postgrest';
+import { normalizeRole } from './userRoleService';
 
 /**
  * Types for dealer show participation
@@ -15,17 +16,6 @@ import { formatInList } from '../utils/postgrest';
  * Normalize a role string (DB may store lowercase) to the lowercase
  * `UserRole` enum used throughout the client.
  */
-const normalizeRole = (role: string | null | undefined): UserRole | null => {
-  if (!role) return null;
-  // FIX: Convert to lowercase to match enum string values
-  const normalizedRoleString = role.toLowerCase();
-  
-  // Check if the normalized string is one of the valid UserRole enum values
-  if (Object.values(UserRole).includes(normalizedRoleString as UserRole)) {
-    return normalizedRoleString as UserRole;
-  }
-  return null;
-};
 
 export interface DealerShowParticipation {
   id: string;

--- a/src/services/showService.ts
+++ b/src/services/showService.ts
@@ -7,6 +7,7 @@
 import { supabase } from '../supabase';
 import { Show, ShowStatus } from '../types';
 import { calculateDistanceBetweenCoordinates } from './locationService';
+import { safeOverlaps } from '../utils/postgrest';
 
 /* ------------------------------------------------------------------ */
 /* WKB (hex) → Lat/Lng helpers                                         */
@@ -572,9 +573,7 @@ export const getShows = async (filters: ShowFilters = {}): Promise<Show[]> => {
     if (typeof filters.maxEntryFee === 'number') {
       query = query.lte('entry_fee', filters.maxEntryFee);
     }
-    if (filters.categories && Array.isArray(filters.categories) && filters.categories.length > 0) {
-      query = query.overlaps('categories', filters.categories);
-    }
+    query = safeOverlaps(query, 'categories', filters.categories as any);
 
     /* ---------- Log basic-query filters for debugging ---------- */
     console.warn('[showService] Executing basic query with filters:', {
@@ -715,9 +714,7 @@ const getDirectPaginatedShows = async (
       countQuery = countQuery.lte('entry_fee', maxEntryFee);
     }
     
-    if (categories && Array.isArray(categories) && categories.length > 0) {
-      countQuery = countQuery.overlaps('categories', categories);
-    }
+    countQuery = safeOverlaps(countQuery, 'categories', categories as any);
     
     // Execute count query
     const { count, error: countError } = await countQuery;

--- a/src/services/userRoleService.ts
+++ b/src/services/userRoleService.ts
@@ -1,13 +1,7 @@
 import { supabase } from '../supabase';
 import { refreshUserSession } from './sessionService';
-
-// User role constants
-export enum UserRole {
-  ATTENDEE = 'attendee',
-  DEALER = 'dealer',
-  MVP_DEALER = 'mvp_dealer',
-  SHOW_ORGANIZER = 'show_organizer',
-}
+import { UserRole } from '../types';
+export { UserRole } from '../types'; // backward-compat re-export
 
 /**
  * Global test-mode flag.

--- a/src/utils/postgrest.ts
+++ b/src/utils/postgrest.ts
@@ -10,3 +10,17 @@ export function formatLargeInList(values: Array<string | null | undefined>, chun
   console.warn(`[postgrest] Large array (${values.length}) used with formatLargeInList.`);
   return formatInList(values.slice(0, chunkSize));
 }
+
+/**
+ * Safely apply a PostgREST `overlaps` filter only when the array is non-empty.
+ * Returns the original query unchanged when the array is empty / null / undefined.
+ *
+ * Example:
+ *   query = safeOverlaps(query, 'categories', selectedCategories);
+ */
+export function safeOverlaps<T>(query: any, column: string, arr?: T[] | null) {
+  if (Array.isArray(arr) && arr.length > 0) {
+    return query.overlaps(column, arr as any);
+  }
+  return query;
+}


### PR DESCRIPTION
…rom userRoleService\n\n- userRoleService now imports and re-exports UserRole from ../types (single source of truth)\n- dealerService: remove local normalizeRole; import shared helper\n\nchore(postgrest): add safeOverlaps helper and adopt in showService\n\n- Apply safeOverlaps for categories in basic and paginated queries\n\nDroid-assisted change